### PR TITLE
fix function signature call for skip_content_types

### DIFF
--- a/lib/contentful/bootstrap/commands/update_space.rb
+++ b/lib/contentful/bootstrap/commands/update_space.rb
@@ -48,7 +48,7 @@ module Contentful
         def update_json_template(space)
           if ::File.exist?(@json_template)
             output "Updating from JSON Template '#{@json_template}'"
-            Templates::JsonTemplate.new(space, @json_template, @mark_processed, false, @skip_content_types).run
+            Templates::JsonTemplate.new(space, @json_template, @mark_processed, true, false, @skip_content_types).run
             output "JSON Template '#{@json_template}' updated!"
           else
             output "JSON Template '#{@json_template}' does not exist. Please check that you specified the correct file name."

--- a/spec/contentful/bootstrap/commands/update_space_spec.rb
+++ b/spec/contentful/bootstrap/commands/update_space_spec.rb
@@ -52,7 +52,7 @@ describe Contentful::Bootstrap::Commands::UpdateSpace do
               expect(subject).to receive(:fetch_space) { space_double }
               expect(mock_template).to receive(:run)
 
-              expect(::Contentful::Bootstrap::Templates::JsonTemplate).to receive(:new).with(space_double, 'bar', mark_processed, false, false) { mock_template }
+              expect(::Contentful::Bootstrap::Templates::JsonTemplate).to receive(:new).with(space_double, 'bar', mark_processed, true, false, false) { mock_template }
 
               subject.run
             end
@@ -71,7 +71,7 @@ describe Contentful::Bootstrap::Commands::UpdateSpace do
           expect(subject).to receive(:fetch_space) { space_double }
           expect(mock_template).to receive(:run)
 
-          expect(::Contentful::Bootstrap::Templates::JsonTemplate).to receive(:new).with(space_double, 'bar', false, false, true) { mock_template }
+          expect(::Contentful::Bootstrap::Templates::JsonTemplate).to receive(:new).with(space_double, 'bar', false, true, false, true) { mock_template }
 
           subject.run
         end


### PR DESCRIPTION
The calls didn't match up to set the skip_content_types, might be a good idea to switch to Ruby function keywords to make it easier to read?