### PR TITLE
rename content_field array? method to not conflict with type-checking…

### DIFF
--- a/lib/contentful/bootstrap/templates/base.rb
+++ b/lib/contentful/bootstrap/templates/base.rb
@@ -73,7 +73,7 @@ module Contentful
                 field.type = f['type']
                 field.link_type = f['linkType'] if link?(f)
 
-                if array?(f)
+                if array_field?(f)
                   array_field = Contentful::Management::Field.new
                   array_field.type = f['items']['type']
                   array_field.link_type = f['items']['linkType']
@@ -103,7 +103,7 @@ module Contentful
           field.key?('linkType')
         end
 
-        def array?(field)
+        def array_field?(field)
           field.key?('items')
         end
 


### PR DESCRIPTION
There is another "array?" method in json_template.rb - this was the one being called in base.rb line 76 instead of the private "array?" method from line 106.

So, this was causing bootstrap imports of spaces with array content types to fail.

After renaming the array? method, the problem is resolved.
